### PR TITLE
Package list improvements

### DIFF
--- a/whiskers/templates/package.pt
+++ b/whiskers/templates/package.pt
@@ -21,16 +21,18 @@
         </ul>
       </div>
 
-      <div tal:condition="not: package" tal:repeat="package packages" class="package-details">
-        <h3 tal:content="string:Version ${package.version.version}" />
-        <p>This package is used by following buildouts:</p>
-        <ul>
-          <li tal:repeat="buildout package.buildouts">
-            <a href="${request.route_url('buildouts')}/${buildout.id}"
-               tal:content="string: ${buildout.name}" />
-          </li>
-        </ul>
-      </div>
+      <tal:packages tal:condition="not: package" tal:repeat="package packages">
+        <div tal:condition="package.buildouts" class="package-details">
+          <h3 tal:content="string:Version ${package.version.version}" />
+          <p>This package is used by following buildouts:</p>
+          <ul>
+            <li tal:repeat="buildout package.buildouts">
+              <a href="${request.route_url('buildouts')}/${buildout.id}"
+                 tal:content="string: ${buildout.name}" />
+            </li>
+          </ul>
+        </div>
+      </tal:packages>
     </div>
   </div>
 </tal:block>

--- a/whiskers/views.py
+++ b/whiskers/views.py
@@ -74,7 +74,8 @@ def package_view(request):
     session = DBSession()
     package_name = request.matchdict['package_name']
     package_id = request.matchdict['id']
-    results = session.query(Package).filter_by(name=package_name)
+    results = session.query(Package).join(Package.version).filter(
+        Package.name==package_name).order_by(Version.version)
     all_packages = results.all()
 
     if len(package_id) > 0:


### PR DESCRIPTION
In these commits I cleaned up the package list a bit by:
- ordering the versions
- not showing versions that do not have related buildouts.

I know that alphabetically ordering the version numbers will not always work (e.g. 4.1 < 4.10 < 4.2), but at least there is some form of ordering. (That is, other than the order in which they were added to the database.)
