### PR TITLE
Use protocol-relative URLS for the dependencies.

### DIFF
--- a/whiskers/templates/master.pt
+++ b/whiskers/templates/master.pt
@@ -9,7 +9,7 @@
     <meta name="keywords" content="whiskers" />
     <meta name="description" content="whiskers" />
     <link rel="shortcut icon" href="${request.static_url('whiskers:static/favicon.ico')}" />
-    <link href='http://fonts.googleapis.com/css?family=Quicksand'
+    <link href='//fonts.googleapis.com/css?family=Quicksand'
           rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="${request.static_url('whiskers:static/css/bootstrap.css')}"
           type="text/css" media="screen" charset="utf-8" />
@@ -28,7 +28,7 @@
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
 
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <tal:block metal:define-slot="custom-head" />
   </head>


### PR DESCRIPTION
We are running whiskers via HTTPS and as a result e.g. the fonts are not loaded because they are requested via plain old HTTP. This should solve that 'problem'.

See http://paulirish.com/2010/the-protocol-relative-url/ for more
information.
